### PR TITLE
Add relative positioning offset.

### DIFF
--- a/CodeGen.py
+++ b/CodeGen.py
@@ -160,6 +160,8 @@ view_propertyGroups = (
                        asserts='%s >= 0',
                        doubleHeight=True,
                         ),
+                   ),
+                  (
                    Property('ignoreDesiredWidth', 'BOOL', 
                        comments=(
                            'If true, the desired width of this view is ignored.',
@@ -173,6 +175,20 @@ view_propertyGroups = (
                            ),
                         ),
                    ),
+                  (
+                   Property('xPositionOffset', 'int',
+                       comments=(
+                           'A relative adjustment to the positioning of this view.',
+                           'This value can be positive or negative.',
+                           ),
+                       ),
+                   Property('yPositionOffset', 'int',
+                       comments=(
+                           'A relative adjustment to the positioning of this view.',
+                           'This value can be positive or negative.',
+                           ),
+                       ),
+                  ),
                   (
                    Property('cellHAlign', 'HAlign',
                        comments=(
@@ -476,6 +492,8 @@ view_customAccessors = (
                     CustomAccessor('stretchWeight', 'CGFloat', ('vStretchWeight', 'hStretchWeight',)),
                 
                     CustomAccessor('ignoreDesiredSize', 'BOOL', ('ignoreDesiredWidth', 'ignoreDesiredHeight',)),
+                    
+                    CustomAccessor('positionOffset', 'CGPoint', ('xPositionOffset', 'yPositionOffset',), ('.x', '.y',)),
                     )
 
 layout_customAccessors = (

--- a/WeView/UIView+WeView.h
+++ b/WeView/UIView+WeView.h
@@ -111,6 +111,18 @@
 - (BOOL)ignoreDesiredHeight;
 - (UIView *)setIgnoreDesiredHeight:(BOOL)value;
 
+// A relative adjustment to the positioning of this view.
+//
+// This value can be positive or negative.
+- (int)xPositionOffset;
+- (UIView *)setXPositionOffset:(int)value;
+
+// A relative adjustment to the positioning of this view.
+//
+// This value can be positive or negative.
+- (int)yPositionOffset;
+- (UIView *)setYPositionOffset:(int)value;
+
 // The horizontal alignment preference of this view within in its layout cell.
 //
 // This value is optional.  The default value is the contentHAlign of its superview.
@@ -166,6 +178,9 @@
 
 // Convenience accessor(s) for the ignoreDesiredWidth and ignoreDesiredHeight properties.
 - (UIView *)setIgnoreDesiredSize:(BOOL)value;
+
+// Convenience accessor(s) for the xPositionOffset and yPositionOffset properties.
+- (UIView *)setPositionOffset:(CGPoint)value;
 
 /* CODEGEN MARKER: Properties End */
 

--- a/WeView/UIView+WeView.m
+++ b/WeView/UIView+WeView.m
@@ -98,6 +98,16 @@ static const void *kWeViewKey_ViewInfo = &kWeViewKey_ViewInfo;
 // This should usually be set in concert with vStretches.
 @property (nonatomic) BOOL ignoreDesiredHeight;
 
+// A relative adjustment to the positioning of this view.
+//
+// This value can be positive or negative.
+@property (nonatomic) int xPositionOffset;
+
+// A relative adjustment to the positioning of this view.
+//
+// This value can be positive or negative.
+@property (nonatomic) int yPositionOffset;
+
 // The horizontal alignment preference of this view within in its layout cell.
 //
 // This value is optional.  The default value is the contentHAlign of its superview.
@@ -147,6 +157,9 @@ static const void *kWeViewKey_ViewInfo = &kWeViewKey_ViewInfo;
 
 // Convenience accessor(s) for the ignoreDesiredWidth and ignoreDesiredHeight properties.
 - (void)setIgnoreDesiredSize:(BOOL)value;
+
+// Convenience accessor(s) for the xPositionOffset and yPositionOffset properties.
+- (void)setPositionOffset:(CGPoint)value;
 
 /* CODEGEN MARKER: View Info Properties End */
 
@@ -246,6 +259,12 @@ static const void *kWeViewKey_ViewInfo = &kWeViewKey_ViewInfo;
     [self setIgnoreDesiredHeight:value];
 }
 
+- (void)setPositionOffset:(CGPoint)value
+{
+    [self setXPositionOffset:value.x];
+    [self setYPositionOffset:value.y];
+}
+
 /* CODEGEN MARKER: View Info M End */
 
 - (NSString *)formatLayoutDescriptionItem:(NSString *)key
@@ -274,6 +293,8 @@ static const void *kWeViewKey_ViewInfo = &kWeViewKey_ViewInfo;
     [result appendString:[self formatLayoutDescriptionItem:@"desiredHeightAdjustment" value:@(self.desiredHeightAdjustment)]];
     [result appendString:[self formatLayoutDescriptionItem:@"ignoreDesiredWidth" value:@(self.ignoreDesiredWidth)]];
     [result appendString:[self formatLayoutDescriptionItem:@"ignoreDesiredHeight" value:@(self.ignoreDesiredHeight)]];
+    [result appendString:[self formatLayoutDescriptionItem:@"xPositionOffset" value:@(self.xPositionOffset)]];
+    [result appendString:[self formatLayoutDescriptionItem:@"yPositionOffset" value:@(self.yPositionOffset)]];
     [result appendString:[self formatLayoutDescriptionItem:@"cellHAlign" value:@(self.cellHAlign)]];
     [result appendString:[self formatLayoutDescriptionItem:@"cellVAlign" value:@(self.cellVAlign)]];
     [result appendString:[self formatLayoutDescriptionItem:@"hasCellHAlign" value:@(self.hasCellHAlign)]];
@@ -480,6 +501,30 @@ static const void *kWeViewKey_ViewInfo = &kWeViewKey_ViewInfo;
     return self;
 }
 
+- (int)xPositionOffset
+{
+    return [self.viewInfo xPositionOffset];
+}
+
+- (UIView *)setXPositionOffset:(int)value
+{
+    [self.viewInfo setXPositionOffset:value];
+    [self.superview setNeedsLayout];
+    return self;
+}
+
+- (int)yPositionOffset
+{
+    return [self.viewInfo yPositionOffset];
+}
+
+- (UIView *)setYPositionOffset:(int)value
+{
+    [self.viewInfo setYPositionOffset:value];
+    [self.superview setNeedsLayout];
+    return self;
+}
+
 - (HAlign)cellHAlign
 {
     return [self.viewInfo cellHAlign];
@@ -629,6 +674,14 @@ static const void *kWeViewKey_ViewInfo = &kWeViewKey_ViewInfo;
 {
     [self setIgnoreDesiredWidth:value];
     [self setIgnoreDesiredHeight:value];
+    [self.superview setNeedsLayout];
+    return self;
+}
+
+- (UIView *)setPositionOffset:(CGPoint)value
+{
+    [self setXPositionOffset:value.x];
+    [self setYPositionOffset:value.y];
     [self.superview setNeedsLayout];
     return self;
 }

--- a/WeView/WeViewProxyView.m
+++ b/WeView/WeViewProxyView.m
@@ -137,6 +137,18 @@
     return [view ignoreDesiredHeight];
 }
 
+- (int)xPositionOffset
+{
+    UIView *view = self.isWeakReference ? self.weakView : self.strongView;
+    return [view xPositionOffset];
+}
+
+- (int)yPositionOffset
+{
+    UIView *view = self.isWeakReference ? self.weakView : self.strongView;
+    return [view yPositionOffset];
+}
+
 - (HAlign)cellHAlign
 {
     UIView *view = self.isWeakReference ? self.weakView : self.strongView;

--- a/WeViews2DemoApp/WeViews2DemoApp.xcodeproj/project.pbxproj
+++ b/WeViews2DemoApp/WeViews2DemoApp.xcodeproj/project.pbxproj
@@ -501,7 +501,7 @@
 		34195F7117CA80A90036F8DC /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0611;
 			};
 			buildConfigurationList = 34195F7417CA80A90036F8DC /* Build configuration list for PBXProject "WeViews2DemoApp" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/WeViews2DemoApp/WeViews2DemoApp/DemoCodeGeneration.m
+++ b/WeViews2DemoApp/WeViews2DemoApp/DemoCodeGeneration.m
@@ -594,6 +594,16 @@ haveAnyOfPrefixes:(NSArray *)prefixes
         [lines addObject:[NSString stringWithFormat:@"%@:%@", @"setIgnoreDesiredHeight", FormatBoolean(view.ignoreDesiredHeight)]];
     }
 
+    if (view.xPositionOffset != virginView.xPositionOffset)
+    {
+        [lines addObject:[NSString stringWithFormat:@"%@:%@", @"setXPositionOffset", FormatInt(view.xPositionOffset)]];
+    }
+
+    if (view.yPositionOffset != virginView.yPositionOffset)
+    {
+        [lines addObject:[NSString stringWithFormat:@"%@:%@", @"setYPositionOffset", FormatInt(view.yPositionOffset)]];
+    }
+
     if (view.cellHAlign != virginView.cellHAlign)
     {
         [lines addObject:[NSString stringWithFormat:@"%@:%@", @"setCellHAlign", ReprHAlign(view.cellHAlign)]];

--- a/WeViews2DemoApp/WeViews2DemoApp/ViewEditorController.m
+++ b/WeViews2DemoApp/WeViews2DemoApp/ViewEditorController.m
@@ -561,6 +561,10 @@ typedef void (^SetterBlock)(id item);
 
                                 [ViewParameterSimple booleanProperty:@"ignoreDesiredHeight"],
 
+                                [ViewParameterSimple intProperty:@"xPositionOffset"],
+
+                                [ViewParameterSimple intProperty:@"yPositionOffset"],
+
                                 [ViewParameterSimple create:@"cellHAlign"
                                                 getterBlock:^NSString *(id item) {
                                                     return FormatHAlign(((UIView *) item).cellHAlign);


### PR DESCRIPTION
PTAL @vfleurima @DawnWright 

![weview-relative-position-offset](https://cloud.githubusercontent.com/assets/625803/8733573/61905a2e-2bd2-11e5-95cd-bc3d32432ebb.gif)

```

#import "WeView.h"

WeView *gridDemo2 = [[WeView alloc] init];
UILabel *label1 = ...;
UILabel *label2 = ...;
UILabel *label3 = ...;
UILabel *label4 = ...;
UIImageView *imageView1 = ...;
UILabel *label5 = ...;
UIImageView *imageView2 = ...;
UILabel *label6 = ...;
UIButton *button1 = ...;
UILabel *label7 = ...;
[[[gridDemo2 addSubviewsWithGridLayout:@[
    label1,
    [[label2 setXPositionOffset:5]
      setYPositionOffset:5],
    label3,
    label4,
    imageView1,
    label5,
    imageView2,
    label6,
    button1,
    label7,
   ] columnCount:3]
  setSpacing:15]
  setMargin:10];
```
